### PR TITLE
Support for base64-encoded payloads

### DIFF
--- a/awsgi/__init__.py
+++ b/awsgi/__init__.py
@@ -44,7 +44,7 @@ class StartResponse:
 
 
 def environ(event, context):
-    if event['isBase64Encoded']:
+    if event.get('isBase64Encoded', False) and event.has_key('body'):
         event['body'] = base64.b64decode(event['body'])
 
     environ = {

--- a/awsgi/__init__.py
+++ b/awsgi/__init__.py
@@ -1,4 +1,5 @@
-from io import StringIO
+import base64
+from io import BytesIO
 import sys
 try:
     # Python 3
@@ -18,7 +19,7 @@ class StartResponse:
     def __init__(self):
         self.status = 500
         self.headers = []
-        self.body = StringIO()
+        self.body = BytesIO()
 
     def __call__(self, status, headers, exc_info=None):
         self.status = status.split()[0]
@@ -31,12 +32,21 @@ class StartResponse:
             'headers': dict(self.headers),
             'body': self.body.getvalue(),
         }
-        for chunk in output:
-            resp['body'] += chunk
+
+        if output:
+            body = bytearray(resp['body'])
+            [body.extend(chunk) for chunk in output]
+
+            resp['body'] = base64.b64encode(body)
+            resp['isBase64Encoded'] = True
+
         return resp
 
 
 def environ(event, context):
+    if event['isBase64Encoded']:
+        event['body'] = base64.b64decode(event['body'])
+
     environ = {
         'REQUEST_METHOD': event['httpMethod'],
         'SCRIPT_NAME': '',
@@ -47,7 +57,7 @@ def environ(event, context):
         'HTTP': 'on',
         'SERVER_PROTOCOL': 'HTTP/1.1',
         'wsgi.version': (1, 0),
-        'wsgi.input': StringIO(event.get('body')),
+        'wsgi.input': BytesIO(event.get('body')),
         'wsgi.errors': sys.stderr,
         'wsgi.multithread': False,
         'wsgi.multiprocess': False,

--- a/awsgi/__init__.py
+++ b/awsgi/__init__.py
@@ -33,10 +33,13 @@ class StartResponse:
             'body': self.body.getvalue(),
         }
 
-        if output:
-            body = bytearray(resp['body'])
-            [body.extend(chunk) for chunk in output]
+        body = None
 
+        for chunk in output:
+            body = body or bytearray(resp['body'])
+            body.extend(chunk)
+
+        if body:
             resp['body'] = base64.b64encode(body)
             resp['isBase64Encoded'] = True
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
 setup(
     name='aws-wsgi',
 
-    version='0.0.6',
+    version='0.1.0',
 
     description='WSGI adapter for AWS API Gateway/Lambda Proxy Integration',
     long_description=long_description,


### PR DESCRIPTION
API Gateway supports base64-encoded request and response bodies and identifies them using the `isBase64Encoded` property.