### PR TITLE
Fixes Execution failed due to configuration error: Malformed Lambda proxy response

### DIFF
--- a/awsgi/__init__.py
+++ b/awsgi/__init__.py
@@ -35,6 +35,7 @@ class StartResponse:
 
     def response(self, output):
         return {
+            'isBase64Encoded': False,
             'statusCode': str(self.status),
             'headers': dict(self.headers),
             'body': self.body.getvalue() + ''.join(map(convert_str, output)),


### PR DESCRIPTION
adds "isBase64Encoded" to APIGateway response
to fix _[Malformed Lambda proxy response](https://aws.amazon.com/premiumsupport/knowledge-center/malformed-502-api-gateway/)_