### PR TITLE
Pass context and event to WSGI environment

### DIFF
--- a/awsgi/__init__.py
+++ b/awsgi/__init__.py
@@ -57,6 +57,8 @@ def environ(event, context):
         'wsgi.multithread': False,
         'wsgi.multiprocess': False,
         'wsgi.run_once': False,
+        'awsgi.event': event,
+        'awsgi.context': context,
     }
     headers = event.get('headers', {})
     for k, v in headers.items():

--- a/test_awsgi.py
+++ b/test_awsgi.py
@@ -47,6 +47,7 @@ class TestAwsgi(unittest.TestCase):
                 'X-forwarded-port': '12345',
             },
         }
+        context = object()
         expected = {
             'REQUEST_METHOD': event['httpMethod'],
             'SCRIPT_NAME': '',
@@ -72,8 +73,10 @@ class TestAwsgi(unittest.TestCase):
             'SERVER_PORT': event['headers']['X-forwarded-port'],
             'HTTP_X_FORWARDED_PORT': event['headers']['X-forwarded-port'],
             'HTTP_X_TEST_SUITE': event['headers']['X-test-suite'],
+            'awsgi.event': event,
+            'awsgi.context': context
         }
-        result = awsgi.environ(event, object())
+        result = awsgi.environ(event, context)
         self.addTypeEqualityFunc(StringIO, self.compareStringIOContents)
         for k, v in result.items():
             self.assertEqual(v, expected[k])


### PR DESCRIPTION
For my use case I needed access to the `context` but I saw https://github.com/slank/awsgi/issues/17 and have added the event also.

As an example, the context in flask is available through:
```python
flask.request.environ['awsgi.context']
```