### PR TITLE
AWS SAM expects an integer status code

### DIFF
--- a/awsgi/__init__.py
+++ b/awsgi/__init__.py
@@ -36,7 +36,7 @@ class StartResponse:
     def response(self, output):
         return {
             'isBase64Encoded': False,
-            'statusCode': str(self.status),
+            'statusCode': int(self.status),
             'headers': dict(self.headers),
             'body': self.body.getvalue() + ''.join(map(convert_str, output)),
         }


### PR DESCRIPTION
The current response returns a stringified `statusCode`. This jams up [AWS SAM](https://github.com/awslabs/serverless-application-model) when it's ran locally:
```
2019-02-12 11:04:31 statusCode must be a positive int
```

Here's the SAM setup to reproduce this: 

`requirements.txt`:
```
aws-wsgi==0.0.8
Flask==1.0.2
```

`api.py`:
```python
import awsgi
from flask import jsonify, Flask

app = Flask(__name__)

@app.route('/')
def index():
    return jsonify(message='OK')

def lambda_handler(event, context):
    return awsgi.response(app, event, context)
```

`template.yaml`:
```yaml
AWSTemplateFormatVersion: '2010-09-09'
Transform: 'AWS::Serverless-2016-10-31'
Resources:
  AppExample:
    Type: 'AWS::Serverless::Function'
    Properties:
      Handler: api.lambda_handler
      Runtime: python3.6
      CodeUri: .
      Events:
        HTTPRoot:
          Type: Api
          Properties:
            Path: /
            Method: any
```

Test locally:
```bash
sam build && sam local start-api --template .aws-sam/template.yaml
```