### PR TITLE
Include authorized user in WSGI environ

### DIFF
--- a/awsgi/__init__.py
+++ b/awsgi/__init__.py
@@ -63,6 +63,13 @@ def environ(event, context):
         'awsgi.event': event,
         'awsgi.context': context,
     }
+
+    request_context = event.get('requestContext')
+    if request_context:
+        remote_user = request_context.get('authorizer', {}).get('principalId')
+        if remote_user:
+            environ['REMOTE_USER'] = remote_user
+
     headers = event.get('headers', {})
     for k, v in headers.items():
         k = k.upper().replace('-', '_')

--- a/test_awsgi.py
+++ b/test_awsgi.py
@@ -2,21 +2,8 @@
 from io import StringIO
 import sys
 import unittest
-try:
-    # Python 3
-    from urllib.parse import urlencode
-
-    # Convert bytes to str, if required
-    def convert_str(s):
-        return s.decode('utf-8') if isinstance(s, bytes) else s
-except:
-    # Python 2
-    from urllib import urlencode
-
-    # No conversion required
-    def convert_str(s):
-        return s
 import awsgi
+from awsgi import urlencode
 
 
 class TestAwsgi(unittest.TestCase):
@@ -30,7 +17,14 @@ class TestAwsgi(unittest.TestCase):
         a.seek(a_loc)
         b.seek(b_loc)
 
+    def verify_environ(self, expected, result):
+        self.addTypeEqualityFunc(StringIO, self.compareStringIOContents)
+        self.assertEqual(result.keys(), expected.keys())
+        for k, v in result.items():
+            self.assertEqual(v, expected[k])
+
     def test_environ(self):
+        """Tests a request with no authorizer context.  The REMOTE_USER should be omitted in this case"""
         event = {
             'httpMethod': 'TEST',
             'path': '/test',
@@ -45,7 +39,7 @@ class TestAwsgi(unittest.TestCase):
                 'X-forwarded-for': 'first, second',
                 'X-forwarded-proto': 'https',
                 'X-forwarded-port': '12345',
-            },
+            }
         }
         context = object()
         expected = {
@@ -77,6 +71,58 @@ class TestAwsgi(unittest.TestCase):
             'awsgi.context': context
         }
         result = awsgi.environ(event, context)
-        self.addTypeEqualityFunc(StringIO, self.compareStringIOContents)
-        for k, v in result.items():
-            self.assertEqual(v, expected[k])
+        self.verify_environ(expected, result)
+
+    def test_environ_with_authorizer(self):
+        """Tests a request with an authorizer context.  The REMOTE_USER should be included"""
+        event = {
+            'httpMethod': 'TEST',
+            'path': '/test',
+            'queryStringParameters': {
+                'test': '✓',
+            },
+            'body': u'test',
+            'headers': {
+                'X-test-suite': 'testing',
+                'Content-type': 'text/plain',
+                'Host': 'test',
+                'X-forwarded-for': 'first, second',
+                'X-forwarded-proto': 'https',
+                'X-forwarded-port': '12345',
+            },
+            'requestContext': {
+                'authorizer': {'principalId': 'user1'}
+            }
+        }
+        context = object()
+        expected = {
+            'REQUEST_METHOD': event['httpMethod'],
+            'SCRIPT_NAME': '',
+            'PATH_INFO': event['path'],
+            'QUERY_STRING': urlencode(event['queryStringParameters']),
+            'CONTENT_LENGTH': str(len(event['body'])),
+            'HTTP': 'on',
+            'SERVER_PROTOCOL': 'HTTP/1.1',
+            'wsgi.version': (1, 0),
+            'wsgi.input': StringIO(event['body']),
+            'wsgi.errors': sys.stderr,
+            'wsgi.multithread': False,
+            'wsgi.multiprocess': False,
+            'wsgi.run_once': False,
+            'CONTENT_TYPE': event['headers']['Content-type'],
+            'HTTP_CONTENT_TYPE': event['headers']['Content-type'],
+            'SERVER_NAME': event['headers']['Host'],
+            'HTTP_HOST': event['headers']['Host'],
+            'REMOTE_ADDR': event['headers']['X-forwarded-for'].split(', ')[0],
+            'HTTP_X_FORWARDED_FOR': event['headers']['X-forwarded-for'],
+            'wsgi.url_scheme': event['headers']['X-forwarded-proto'],
+            'HTTP_X_FORWARDED_PROTO': event['headers']['X-forwarded-proto'],
+            'SERVER_PORT': event['headers']['X-forwarded-port'],
+            'HTTP_X_FORWARDED_PORT': event['headers']['X-forwarded-port'],
+            'HTTP_X_TEST_SUITE': event['headers']['X-test-suite'],
+            'awsgi.event': event,
+            'awsgi.context': context,
+            'REMOTE_USER': 'user1'
+        }
+        result = awsgi.environ(event, context)
+        self.verify_environ(expected, result)

--- a/test_awsgi.py
+++ b/test_awsgi.py
@@ -19,7 +19,7 @@ class TestAwsgi(unittest.TestCase):
 
     def verify_environ(self, expected, result):
         self.addTypeEqualityFunc(StringIO, self.compareStringIOContents)
-        self.assertEqual(result.keys(), expected.keys())
+        self.assertEqual(set(result.keys()), set(expected.keys()))
         for k, v in result.items():
             self.assertEqual(v, expected[k])
 


### PR DESCRIPTION
The [WSGI Docs](https://wsgi.readthedocs.io/en/latest/specifications/simple_authentication.html) allow for a `REMOTE_USER` environ to indicate the username of the current authenticated user.  If there is no authenticated user, then the `REMOTE_USER` is to be omitted.

A Lambda invoked with a custom authorizer will include the following structure:
```
{
  ...,
  'requestContext': {
    ...,
    'authorizer': {
      'principalId': 'str|int',
      ...
    }
  }
}
```

This PR will include that `principalId` as the WSGI environ `REMOTE_USER` if and only if there is a `principalId` present.  I've included two tests: one with and one without an authorizer context.