### PR TITLE
Support Base 64 Encoded Response Body

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,4 +34,4 @@ Example
 
 
     def lambda_handler(event, context):
-        return awsgi.response(app, event, context)
+        return awsgi.response(app, event, context, base64_content_types={"image/png"})


### PR DESCRIPTION
# Motivation

Return binary response data from an AWS Lambda/API Gateway integration - such as images, pdfs etc. API Gateway supports this via base 64 encoding the response body and configuring *binary media types*. The expected response from a Lambda functions is:

```python
{
            "isBase64Encoded": true,
            "statusCode": 200,
            "headers": {"Content-Type": "image/png", ...},
            "body": "b64 encoded blob"
}
```

`awsgi` currently does not support this, although a previous PR attempting to support this https://github.com/slank/awsgi/pull/1 was closed due to inactivity.

# Changes

Provide a `base64_content_types` kwarg to `awsgi.response`. This is a set of HTTP content-types which should be base 64 encoded as above - allowing the user to specify which content types should behave in this way (instead of hard-coding the behaviour in the library). When a `Content-Type` header in the wsgi response matches one of those specified in `base64_content_types`, the body is base 64 encoded and the `isBase64Encoded` response `dict` key is set to `True`.

# Example Usage With Flask
**Note**: routes returning text function as before with no base 64 encoding, only the `/image` route will be base 64 encoded due to it's `Content-Type`.
```python
import awsgi
from flask import Flask, send_file, render_template, jsonify

app = Flask(__name__)

@app.route("/")
def index():
    return render_template("index.html")

@app.route("/json")
def json():
    return jsonify({"key": "val", "key2": "val2"})

@app.route("/image")
def image():
    return send_file("my_image.png", mimetype="image/png")


def lambda_handler(event, context):
    return awsgi.response(app, event, context, base64_content_types={"image/png"})
```