### PR TITLE
Improve Elastic Load Balancer compatibility

### DIFF
--- a/awsgi/__init__.py
+++ b/awsgi/__init__.py
@@ -137,7 +137,7 @@ def environ(event, context):
 
 
 def select_impl(event, context):
-    if 'elb' in context:
+    if 'elb' in event['requestContext']:
         return environ, StartResponse_ELB
     else:
         return environ, StartResponse_GW

--- a/awsgi/__init__.py
+++ b/awsgi/__init__.py
@@ -8,7 +8,7 @@ try:
     # Convert bytes to str, if required
     def convert_str(s):
         return s.decode('utf-8') if isinstance(s, bytes) else s
-except:
+except ImportError:
     # Python 2
     from urllib import urlencode
 

--- a/awsgi/__init__.py
+++ b/awsgi/__init__.py
@@ -1,4 +1,4 @@
-from io import StringIO, BytesIO
+from io import BytesIO
 from base64 import b64encode, b64decode
 import itertools
 import collections

--- a/awsgi/__init__.py
+++ b/awsgi/__init__.py
@@ -36,12 +36,14 @@ class StartResponse:
             API Gateway.
         '''
         self.status = 500
+        self.status_line = '500 Internal Server Error'
         self.headers = []
         self.body = StringIO()
         self.base64_content_types = set(base64_content_types) or set()
 
     def __call__(self, status, headers, exc_info=None):
-        self.status = status.split()[0]
+        self.status_line = status
+        self.status = int(status.split()[0])
         self.headers[:] = headers
         return self.body.write
 
@@ -56,7 +58,8 @@ class StartResponse:
 
         return {
             'isBase64Encoded': is_b64,
-            'statusCode': str(self.status),
+            'statusCode': int(self.status),
+            'statusDescription': self.status_line,
             'headers': headers,
             'body': self.body.getvalue() + converted_output,
         }

--- a/test_awsgi.py
+++ b/test_awsgi.py
@@ -101,4 +101,4 @@ class TestAwsgi(unittest.TestCase):
 
         result = sr.response(output)
         self.assertTrue(result["isBase64Encoded"])
-        self.assertEqual(result["body"], "iVBORw0KGgo=AAAADUlIRFIAAADI")
+        self.assertEqual(result["body"], 'iVBORw0KGgoAAAANSUhEUgAAAMg=')

--- a/test_awsgi.py
+++ b/test_awsgi.py
@@ -97,3 +97,88 @@ class TestAwsgi(unittest.TestCase):
         result = sr.response(output)
         self.assertTrue(result["isBase64Encoded"])
         self.assertEqual(result["body"], 'iVBORw0KGgoAAAANSUhEUgAAAMg=')
+
+    def test_impl_selection_elb(self):
+        event = {
+            "requestContext": {
+                "elb": {
+                    "targetGroupArn": "arn:aws:elasticloadbalancing:us-east-2:0123456789:targetgroup/spam/eggs"
+                }
+            },
+            "httpMethod": "GET",
+            "path": "/",
+            "multiValueQueryStringParameters": {},
+            "multiValueHeaders": {
+                "user-agent": [
+                    "ELB-HealthChecker/2.0"
+                ]
+            },
+            "body": "",
+            "isBase64Encoded": False
+        }
+        context = object()
+        environ, StartResponse = awsgi.select_impl(event, context)
+        self.assertIs(environ, awsgi.environ)
+        self.assertIs(StartResponse, awsgi.StartResponse_ELB)
+
+    def test_impl_selection_gw(self):
+        # From https://docs.aws.amazon.com/lambda/latest/dg/with-on-demand-https.html?shortFooter=true
+        event = {
+          "path": "/test/hello",
+          "headers": {
+            "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
+            "Accept-Encoding": "gzip, deflate, lzma, sdch, br",
+            "Accept-Language": "en-US,en;q=0.8",
+            "CloudFront-Forwarded-Proto": "https",
+            "CloudFront-Is-Desktop-Viewer": "true",
+            "CloudFront-Is-Mobile-Viewer": "false",
+            "CloudFront-Is-SmartTV-Viewer": "false",
+            "CloudFront-Is-Tablet-Viewer": "false",
+            "CloudFront-Viewer-Country": "US",
+            "Host": "wt6mne2s9k.execute-api.us-west-2.amazonaws.com",
+            "Upgrade-Insecure-Requests": "1",
+            "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.82 Safari/537.36 OPR/39.0.2256.48",
+            "Via": "1.1 fb7cca60f0ecd82ce07790c9c5eef16c.cloudfront.net (CloudFront)",
+            "X-Amz-Cf-Id": "nBsWBOrSHMgnaROZJK1wGCZ9PcRcSpq_oSXZNQwQ10OTZL4cimZo3g==",
+            "X-Forwarded-For": "192.168.100.1, 192.168.1.1",
+            "X-Forwarded-Port": "443",
+            "X-Forwarded-Proto": "https"
+          },
+          "pathParameters": {
+            "proxy": "hello"
+          },
+          "requestContext": {
+            "accountId": "123456789012",
+            "resourceId": "us4z18",
+            "stage": "test",
+            "requestId": "41b45ea3-70b5-11e6-b7bd-69b5aaebc7d9",
+            "identity": {
+              "cognitoIdentityPoolId": "",
+              "accountId": "",
+              "cognitoIdentityId": "",
+              "caller": "",
+              "apiKey": "",
+              "sourceIp": "192.168.100.1",
+              "cognitoAuthenticationType": "",
+              "cognitoAuthenticationProvider": "",
+              "userArn": "",
+              "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.82 Safari/537.36 OPR/39.0.2256.48",
+              "user": ""
+            },
+            "resourcePath": "/{proxy+}",
+            "httpMethod": "GET",
+            "apiId": "wt6mne2s9k"
+          },
+          "resource": "/{proxy+}",
+          "httpMethod": "GET",
+          "queryStringParameters": {
+            "name": "me"
+          },
+          "stageVariables": {
+            "stageVarName": "stageVarValue"
+          }
+        }
+        context = object()
+        environ, StartResponse = awsgi.select_impl(event, context)
+        self.assertIs(environ, awsgi.environ)
+        self.assertIs(StartResponse, awsgi.StartResponse_GW)


### PR DESCRIPTION
Last November, AWS added the ability for Elastic Load Balancers to also talk to Lambda functions, and the schemas between ELB and APIGW _almost_ match.

This fixes compatibility with ELB.