### PR TITLE
Add support for base64-encoded requests

### DIFF
--- a/awsgi/__init__.py
+++ b/awsgi/__init__.py
@@ -67,8 +67,9 @@ def environ(event, context):
         body = b64decode(event.get('body', '') or '')
         bodyobj = BytesIO(body)
     else:
+        # FIXME: Flag the encoding in the headers
         body = event.get('body', '') or ''
-        bodyobj = StringIO(body)
+        bodyobj = BytesIO(body.encode('utf-8'))
 
     environ = {
         'REQUEST_METHOD': event['httpMethod'],

--- a/awsgi/__init__.py
+++ b/awsgi/__init__.py
@@ -64,12 +64,12 @@ class StartResponse:
 
 def environ(event, context):
     if event.get('isBase64Encoded', False):
-        body = b64decode(event.get('body', '') or '')
-        bodyobj = BytesIO(body)
+        body_buffer = b64decode(event.get('body', '') or '')
+        body_file = BytesIO(body_buffer)
     else:
         # FIXME: Flag the encoding in the headers
-        body = event.get('body', '') or ''
-        bodyobj = BytesIO(body.encode('utf-8'))
+        body_buffer = event.get('body', '') or ''
+        body_file = BytesIO(body_buffer.encode('utf-8'))
 
     environ = {
         'REQUEST_METHOD': event['httpMethod'],
@@ -79,11 +79,11 @@ def environ(event, context):
         'PATH_INFO': event['path'],
         'QUERY_STRING': urlencode(event['queryStringParameters'] or {}),
         'REMOTE_ADDR': '127.0.0.1',
-        'CONTENT_LENGTH': str(len(body)),
+        'CONTENT_LENGTH': str(len(body_buffer)),
         'HTTP': 'on',
         'SERVER_PROTOCOL': 'HTTP/1.1',
         'wsgi.version': (1, 0),
-        'wsgi.input': bodyobj,
+        'wsgi.input': body_file,
         'wsgi.errors': sys.stderr,
         'wsgi.multithread': False,
         'wsgi.multiprocess': False,

--- a/awsgi/__init__.py
+++ b/awsgi/__init__.py
@@ -68,7 +68,7 @@ def environ(event, context):
         bodyobj = BytesIO(body)
     else:
         body = event.get('body', '') or ''
-        bodyobj = StringIO()
+        bodyobj = StringIO(body)
 
     environ = {
         'REQUEST_METHOD': event['httpMethod'],

--- a/test_awsgi.py
+++ b/test_awsgi.py
@@ -21,14 +21,8 @@ import awsgi
 
 class TestAwsgi(unittest.TestCase):
     def compareStringIOContents(self, a, b, msg=None):
-        a_loc = a.tell()
-        b_loc = b.tell()
-        a.seek(0)
-        b.seek(0)
-        if a.read() != b.read():
+        if a.getvalue() != b.getvalue():
             raise self.failureException(msg)
-        a.seek(a_loc)
-        b.seek(b_loc)
 
     def test_environ(self):
         event = {
@@ -57,7 +51,7 @@ class TestAwsgi(unittest.TestCase):
             'HTTP': 'on',
             'SERVER_PROTOCOL': 'HTTP/1.1',
             'wsgi.version': (1, 0),
-            'wsgi.input': StringIO(event['body']),
+            'wsgi.input': BytesIO(event['body'].encode('utf-8')),
             'wsgi.errors': sys.stderr,
             'wsgi.multithread': False,
             'wsgi.multiprocess': False,
@@ -78,6 +72,7 @@ class TestAwsgi(unittest.TestCase):
         }
         result = awsgi.environ(event, context)
         self.addTypeEqualityFunc(StringIO, self.compareStringIOContents)
+        self.addTypeEqualityFunc(BytesIO, self.compareStringIOContents)
         for k, v in result.items():
             self.assertEqual(v, expected[k])
 


### PR DESCRIPTION
ELB will base64 request bodies if it detects they're binary.

Handle this.