### PR TITLE
Handle Content-Type when it contains a charset

### DIFF
--- a/awsgi/__init__.py
+++ b/awsgi/__init__.py
@@ -56,7 +56,10 @@ class StartResponse(object):
         return self.chunks.append
 
     def use_binary_response(self, headers, body):
-        return headers.get('Content-Type') in self.base64_content_types
+        content_type = headers.get('Content-Type')
+        if ';' in content_type:
+            content_type = content_type.split(';')[0]
+        return content_type in self.base64_content_types
 
     def build_body(self, headers, output):
         totalbody = b''.join(itertools.chain(


### PR DESCRIPTION
For example: Content-Type': 'text/html; charset=utf-8'.

If this is not done, the base_content_types may not match the value in the event and you get a error like the following:

[ERROR] UnicodeDecodeError: 'utf-8' codec can't decode byte 0x8b in position 1: invalid start byte
Traceback (most recent call last):
  File "/var/task/gofer_flask_lambda.py", line 656, in lambda_handler
    base64_content_types={"image/jpeg","text/html"}
  File "/var/task/awsgi/__init__.py", line 173, in response
    return sr.response(output)
  File "/var/task/awsgi/__init__.py", line 95, in response
    rv = super(StartResponse_GW, self).response(output)
  File "/var/task/awsgi/__init__.py", line 89, in response
    rv.update(self.build_body(headers, output))
  File "/var/task/awsgi/__init__.py", line 75, in build_body
    converted_output = convert_str(totalbody)
  File "/var/task/awsgi/__init__.py", line 13, in convert_str
    return s.decode('utf-8') if isinstance(s, bytes) else s