### PR TITLE
feat(awsgi): add support to multi-value query parameters for AWS Gateway

### DIFF
--- a/awsgi/__init__.py
+++ b/awsgi/__init__.py
@@ -117,13 +117,20 @@ def environ(event, context):
     # FIXME: Flag the encoding in the headers
     body = convert_byte(body)
 
+    query_string = event['queryStringParameters'] or {}
+    if 'multiValueQueryStringParameters' in event and event['multiValueQueryStringParameters']:
+        query_string = []
+        for key in event['multiValueQueryStringParameters']:
+            for value in event['multiValueQueryStringParameters'][key]:
+                query_string.append((key, value))
+
     environ = {
         'REQUEST_METHOD': event['httpMethod'],
         'SCRIPT_NAME': '',
         'SERVER_NAME': '',
         'SERVER_PORT': '',
         'PATH_INFO': event['path'],
-        'QUERY_STRING': urlencode(event['queryStringParameters'] or {}),
+        'QUERY_STRING': urlencode(query_string),
         'REMOTE_ADDR': '127.0.0.1',
         'CONTENT_LENGTH': str(len(body)),
         'HTTP': 'on',


### PR DESCRIPTION
Every event received has the queryStringParameters and the multiValueQueryStringParameters, if the second contains values always overrides the queryStringParameters parameter.
Flask get params works with request.args  (Tested with 1.0.3 Flask version and python 3.7)
Further information: https://aws.amazon.com/es/blogs/compute/support-for-multi-value-parameters-in-amazon-api-gateway/