### PR TITLE
Add support for retrieving HTTP payload 2.0 method and path info

### DIFF
--- a/awsgi/__init__.py
+++ b/awsgi/__init__.py
@@ -111,7 +111,7 @@ class StartResponse_ELB(StartResponse):
 
 def environ(event, context):
     
-    # Check if format version is in v2
+    # Check if format version is in v2, used for determining where to retrieve http method and path
     is_v2 = '2.0' in event.get('version', {})
 
     body = event.get('body', '') or ''
@@ -120,16 +120,16 @@ def environ(event, context):
         body = b64decode(body)
     # FIXME: Flag the encoding in the headers
     body = convert_byte(body)
-
-    """
-    """
     environ = {
+        # Get http method from within requestContext.http field in V2 format
         'REQUEST_METHOD': event['requestContext']['http']['method'] if is_v2 else event['httpMethod'],
         'SCRIPT_NAME': '',
         'SERVER_NAME': '',
         'SERVER_PORT': '',
+        # Get path from within requestContext.http field in V2 format
         'PATH_INFO': event['requestContext']['http']['path'] if is_v2 else event['path'],
-        'QUERY_STRING': urlencode(event['queryStringParameters'] or {}),
+        # Use get() to access queryStringParameter field without throwing error if it doesn't exist
+        'QUERY_STRING': urlencode(event.get('queryStringParameters') or {}),
         'REMOTE_ADDR': '127.0.0.1',
         'CONTENT_LENGTH': str(len(body)),
         'HTTP': 'on',

--- a/test_awsgi.py
+++ b/test_awsgi.py
@@ -34,8 +34,9 @@ class TestAwsgi(unittest.TestCase):
         if a.getvalue() != b.getvalue():
             raise self.failureException(msg)
 
-    def test_environ(self):
+    def test_environ_v1(self):
         event = {
+            'version': '1.0',
             'httpMethod': 'TEST',
             'path': '/test',
             'queryStringParameters': {
@@ -56,6 +57,65 @@ class TestAwsgi(unittest.TestCase):
             'REQUEST_METHOD': event['httpMethod'],
             'SCRIPT_NAME': '',
             'PATH_INFO': event['path'],
+            'QUERY_STRING': urlencode(event['queryStringParameters']),
+            'CONTENT_LENGTH': str(len(event['body'])),
+            'HTTP': 'on',
+            'SERVER_PROTOCOL': 'HTTP/1.1',
+            'wsgi.version': (1, 0),
+            'wsgi.input': BytesIO(event['body'].encode('utf-8')),
+            'wsgi.errors': sys.stderr,
+            'wsgi.multithread': False,
+            'wsgi.multiprocess': False,
+            'wsgi.run_once': False,
+            'CONTENT_TYPE': event['headers']['Content-type'],
+            'HTTP_CONTENT_TYPE': event['headers']['Content-type'],
+            'SERVER_NAME': event['headers']['Host'],
+            'HTTP_HOST': event['headers']['Host'],
+            'REMOTE_ADDR': event['headers']['X-forwarded-for'].split(', ')[0],
+            'HTTP_X_FORWARDED_FOR': event['headers']['X-forwarded-for'],
+            'wsgi.url_scheme': event['headers']['X-forwarded-proto'],
+            'HTTP_X_FORWARDED_PROTO': event['headers']['X-forwarded-proto'],
+            'SERVER_PORT': event['headers']['X-forwarded-port'],
+            'HTTP_X_FORWARDED_PORT': event['headers']['X-forwarded-port'],
+            'HTTP_X_TEST_SUITE': event['headers']['X-test-suite'],
+            'awsgi.event': event,
+            'awsgi.context': context
+        }
+        result = awsgi.environ(event, context)
+        self.addTypeEqualityFunc(BytesIO, self.compareStringIOContents)
+        for k, v in result.items():
+            self.assertEqual(v, expected[k])
+
+    def test_environ_v2(self):
+        """
+        Same test as above but with version 2.0 format where http method and path are nested in requestsContext.http attribute.
+        """
+        event = {
+            'version': '2.0',
+            'queryStringParameters': {
+                'test': '✓',
+            },
+            'requestContext': {
+                'http': {
+                    'method': 'TEST',
+                    'path': '/text',
+                }
+            },
+            'body': u'test',
+            'headers': {
+                'X-test-suite': 'testing',
+                'Content-type': 'text/plain',
+                'Host': 'test',
+                'X-forwarded-for': 'first, second',
+                'X-forwarded-proto': 'https',
+                'X-forwarded-port': '12345',
+            },
+        }
+        context = object()
+        expected = {
+            'REQUEST_METHOD': event['requestContext']['http']['method'],
+            'SCRIPT_NAME': '',
+            'PATH_INFO': event['requestContext']['http']['path'],
             'QUERY_STRING': urlencode(event['queryStringParameters']),
             'CONTENT_LENGTH': str(len(event['body'])),
             'HTTP': 'on',


### PR DESCRIPTION
The new format for HTTP payload (v2.0), nests the fields for the request method and path inside the requestContext.http field causing the lambda instance to fail with KeyErrors when accessing the httpMethod/path fields in event.