### PR TITLE
Unquote paths

### DIFF
--- a/awsgi/__init__.py
+++ b/awsgi/__init__.py
@@ -9,7 +9,10 @@ try:
 
     # Convert bytes to str, if required
     def convert_str(s):
-        return s.decode('utf-8') if isinstance(s, bytes) else s
+        try:
+            return s.decode('utf-8') if isinstance(s, bytes) else s
+        except UnicodeDecodeError:
+            return s.encode("latin-1").decode("utf-8")
 
     # Convert str to bytes, if required
     def convert_byte(b):

--- a/awsgi/__init__.py
+++ b/awsgi/__init__.py
@@ -5,7 +5,7 @@ import collections
 import sys
 try:
     # Python 3
-    from urllib.parse import urlencode
+    from urllib.parse import urlencode, unquote
 
     # Convert bytes to str, if required
     def convert_str(s):
@@ -15,9 +15,16 @@ try:
     def convert_byte(b):
         return b.encode('utf-8', errors='strict') if (
             isinstance(b, str)) else b
+
+    def clean_path_string(path):
+        """
+        Some WSGI applications expect paths to be unquoted before receiving them
+        """
+        return unquote(path)
+
 except ImportError:
     # Python 2
-    from urllib import urlencode
+    from urllib import urlencode, unquote
 
     # No conversion required
     def convert_str(s):
@@ -27,6 +34,12 @@ except ImportError:
     def convert_byte(b):
         return b.encode('utf-8', errors='strict') if (
             isinstance(b, (str, unicode))) else b
+
+    def clean_path_string(path):
+        """
+        Some WSGI applications expect paths to be unquoted before receiving them
+        """
+        return unquote(path)
 
 __all__ = 'response',
 
@@ -122,7 +135,7 @@ def environ(event, context):
         'SCRIPT_NAME': '',
         'SERVER_NAME': '',
         'SERVER_PORT': '',
-        'PATH_INFO': event['path'],
+        'PATH_INFO': clean_path_string(event['path']),
         'QUERY_STRING': urlencode(event['queryStringParameters'] or {}),
         'REMOTE_ADDR': '127.0.0.1',
         'CONTENT_LENGTH': str(len(body)),

--- a/test_awsgi.py
+++ b/test_awsgi.py
@@ -208,6 +208,54 @@ class TestAwsgi(unittest.TestCase):
         result = sr.response(output)
         self.assertEqual(result['statusCode'], '200')
 
+    def test_paths_unquoted(self):
+        event = {
+            'httpMethod': 'GET',
+            'path': '/test%20path%20with%20spaces',
+            'queryStringParameters': {},
+            'body': u'test',
+            'headers': {
+                'X-test-suite': 'testing',
+                'Content-type': 'text/plain',
+                'Host': 'test',
+                'X-forwarded-for': 'first, second',
+                'X-forwarded-proto': 'https',
+                'X-forwarded-port': '12345',
+            },
+        }
+        context = object()
+        expected = {
+            'REQUEST_METHOD': event['httpMethod'],
+            'SCRIPT_NAME': '',
+            'PATH_INFO': "/test path with spaces",
+            'QUERY_STRING': "",
+            'CONTENT_LENGTH': str(len(event['body'])),
+            'HTTP': 'on',
+            'SERVER_PROTOCOL': 'HTTP/1.1',
+            'wsgi.version': (1, 0),
+            'wsgi.input': BytesIO(event['body'].encode('utf-8')),
+            'wsgi.errors': sys.stderr,
+            'wsgi.multithread': False,
+            'wsgi.multiprocess': False,
+            'wsgi.run_once': False,
+            'CONTENT_TYPE': event['headers']['Content-type'],
+            'HTTP_CONTENT_TYPE': event['headers']['Content-type'],
+            'SERVER_NAME': event['headers']['Host'],
+            'HTTP_HOST': event['headers']['Host'],
+            'REMOTE_ADDR': event['headers']['X-forwarded-for'].split(', ')[0],
+            'HTTP_X_FORWARDED_FOR': event['headers']['X-forwarded-for'],
+            'wsgi.url_scheme': event['headers']['X-forwarded-proto'],
+            'HTTP_X_FORWARDED_PROTO': event['headers']['X-forwarded-proto'],
+            'SERVER_PORT': event['headers']['X-forwarded-port'],
+            'HTTP_X_FORWARDED_PORT': event['headers']['X-forwarded-port'],
+            'HTTP_X_TEST_SUITE': event['headers']['X-test-suite'],
+            'awsgi.event': event,
+            'awsgi.context': context
+        }
+        result = awsgi.environ(event, context)
+        self.addTypeEqualityFunc(BytesIO, self.compareStringIOContents)
+        for k, v in result.items():
+            self.assertEqual(v, expected[k])
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Some WSGI applications expect that the path is unquoted before receiving it.

Discovered while working with @jpluscplusm. 
